### PR TITLE
Add files via upload

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -85,6 +85,7 @@ typedef struct nwipe_context_t_
     char* device_name;  // The device file name.
     long long device_size;  // The device size in bytes.
     char* device_size_text;  // The device size in a more (human)readable format.
+    double device_size_GB;	// The device size in a gigabytes (GiB), in float format for GUI.
     char* device_model;  // The model of the device.
     char device_label[NWIPE_DEVICE_LABEL_LENGTH];  // The label (name, model, size and serial) of the device.
     struct stat device_stat;  // The device file state from fstat().
@@ -110,6 +111,8 @@ typedef struct nwipe_context_t_
     u64 round_size;  // The total number of i/o bytes across all rounds.
     double round_percent;  // The percentage complete across all rounds.
     int round_working;  // The current working round.
+    time_t round_starttm;	// Start time of rounds; used to determine total throughput.
+    time_t round_endtm;		// End time of rounds; used to determine total throughput.
     nwipe_select_t select;  // Indicates whether this device should be wiped.
     int signal;  // Set when the child is killed by a signal.
     nwipe_speedring_t speedring;  // Ring buffer for computing the rolling throughput average.

--- a/src/device.c
+++ b/src/device.c
@@ -152,8 +152,7 @@ int check_device( nwipe_context_t*** c, PedDevice* dev, int dcount )
     next_device->device_name = dev->path;
     next_device->device_size = dev->length * dev->sector_size;
     next_device->device_size_text = ped_unit_format_byte( dev, dev->length * dev->sector_size );
-    next_device->result = -2;
-
+    next_device->device_size_GB = (double) ( next_device->device_size / ( 1024L * 1024L ) ) / 1024.0; /* For GUI */
     /* Attempt to get serial number of device. */
     if( ( fd = open( next_device->device_name = dev->path, O_RDONLY ) ) == ERR )
     {

--- a/src/method.c
+++ b/src/method.c
@@ -645,6 +645,9 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
     /* An index variable. */
     int i = 0;
 
+    /* Buffer for formatted time. (start, end) */
+    char fmtTm[80];
+
     /* Variable to track if it is the last pass */
     int lastpass = 0;
 
@@ -707,6 +710,11 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
                "Invoking method '%s' on device '%s'.",
                nwipe_method_label( nwipe_options.method ),
                c->device_name );
+
+    c->round_starttm = time( NULL );
+
+    strftime( fmtTm, 80, "%F %T", localtime( &c->round_starttm ) );
+    nwipe_log( NWIPE_LOG_NOTICE, "Started with device '%s' at %s", c->device_name, fmtTm );
 
     while( c->round_working < c->round_count )
     {
@@ -1010,6 +1018,17 @@ int nwipe_runmethod( nwipe_context_t* c, nwipe_pattern_t* patterns )
 
     /* Tell the parent that we have fininshed the final pass. */
     c->pass_type = NWIPE_PASS_NONE;
+
+    /* Mark the end of the rounds, used by GUI for overall throughput. */
+    c->round_endtm = time( NULL );
+
+    strftime( fmtTm, 80, "%F %T", localtime( &c->round_endtm ) );
+    nwipe_log( NWIPE_LOG_NOTICE, "Finished with device '%s' at %s", c->device_name, fmtTm );
+    nwipe_log( NWIPE_LOG_NOTICE,
+               "%s: %lld bytes in %ld seconds",
+               c->device_name,
+               c->device_size,
+               ( c->round_endtm - c->round_starttm ) );
 
     if( c->verify_errors > 0 )
     {


### PR DESCRIPTION
I propose some changes to 0.27rc1.
I saw an anomaly in throughput values in GUI's final summary screen.  Some drives, and a different number of them on different runs, would show a throughput of 1 B/s.  I have added code to capture start/end times of runs, and report "Overall" throughput on final summary.  This also is in response to long-standing throughput values being a "most recent" value which was not a good representation of the drive's overall performance.  Along with this, there are added nwipe_log entries in method.c to mark the start & end.
In gui.c I have changed the running and final summary model/serial#/size display to show these in a more columnar format rather than having the fields smashed up against each other which makes your eyes have to hunt for the values when several drives are being wiped simultaneously.
I have changed the "[syncing]" field to come after the rest of the values so it does not "push" the throughput value to the right.
Original:
![image](https://user-images.githubusercontent.com/55356734/73968577-8127d680-48df-11ea-8e20-d4c38d0a8ace.png)
This Pull Request:
![image](https://user-images.githubusercontent.com/55356734/73968869-057a5980-48e0-11ea-9886-22e0ee91f037.png)
Original summary:
![image](https://user-images.githubusercontent.com/55356734/73969083-5b4f0180-48e0-11ea-8c56-cf4ada6568cf.png)
This Pull Request summary; note "Overall" is calculated from start/stop times of runs, one of the "most recent" throughput values is "1 B/s":
![image](https://user-images.githubusercontent.com/55356734/73969327-d1536880-48e0-11ea-893a-28cd54355703.png)
Changes were made in gui.c to select string values within a switch statement and then doing a single display with wprintw().  This is a baby step toward multi-lingual support (expand list of strings to a table where columns represent different languages) and makes it a single place to change on-screen formatting.  (Again, I like to columnarize things to make it easy to visually scan for info.)
In gui.c, I made a "political" change in line 1677 from "American Department of Defense" to "U.S. Department of Defense".  While the USA is colloquially called "America" the DoD's official name is "U.S. Department of Defense", and other countries in the Americas might not like being lumped in with the U.S.'s DoD.
Changes were made in context.h, device.c and gui.c to add a "device_size_GB" which calculates the device's size once in GiB for later display.  A minor efficiency improvement since there are very few sub-1GiB devices floating around anymore, and handles TB nicely (for now).
